### PR TITLE
Add volume normalization option

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -20,6 +20,8 @@
       </optgroup>
       {% endfor %}
     </select><br><br>
+    <label for="target_db">目標音量(dB):</label>
+    <input type="number" name="target_db" id="target_db" value="{{ target_db }}" step="0.1"><br><br>
     <button type="button" id="previewBtn">BGM視聴</button><br><br>
     <audio id="previewAudio"></audio>
     <button type="submit">ミックスしてダウンロード</button>

--- a/work.py
+++ b/work.py
@@ -1,7 +1,7 @@
 import os
 from pydub import AudioSegment
 
-DEFAULT_TARGET_DB = 89.0
+DEFAULT_TARGET_DB = 80.0
 
 
 def normalize_volume(audio: AudioSegment, target_db: float = DEFAULT_TARGET_DB) -> AudioSegment:

--- a/work.py
+++ b/work.py
@@ -1,6 +1,17 @@
 import os
 from pydub import AudioSegment
 
+DEFAULT_TARGET_DB = 89.0
+
+
+def normalize_volume(audio: AudioSegment, target_db: float = DEFAULT_TARGET_DB) -> AudioSegment:
+  """音源の全体音量をtarget_dbに近づける。"""
+  if audio.dBFS == float('-inf'):
+    return audio
+  target_dbfs = target_db - 100
+  gain = target_dbfs - audio.dBFS
+  return audio.apply_gain(gain)
+
 BGM_FOLDER = os.path.join(os.path.dirname(__file__), 'bgm')
 BGM_DUCK_DB = -20.0 # BGMをポッドキャスト再生中に10%の音量にする（約-20dB） 20 * log10(0.1) = -20 dB
 


### PR DESCRIPTION
## Summary
- add volume normalization utilities and default setting
- support volume adjustment parameter in upload form
- apply user-specified target volume when mixing audio

## Testing
- `python -m py_compile app.py work.py`

------
https://chatgpt.com/codex/tasks/task_e_68538639c668832284684c03e008693d