### PR TITLE
Add cover art generator

### DIFF
--- a/static/js/cover.js
+++ b/static/js/cover.js
@@ -1,0 +1,45 @@
+const audioInput = document.getElementById('audio');
+const titleInput = document.getElementById('title');
+const genreInput = document.getElementById('genre');
+const templateSelect = document.getElementById('template');
+const coverArea = document.getElementById('coverArea');
+const coverDownload = document.getElementById('coverDownload');
+
+function loadTemplates() {
+  fetch('/cover_templates')
+    .then(r => r.json())
+    .then(tmpls => {
+      tmpls.forEach(t => {
+        const opt = document.createElement('option');
+        opt.value = t;
+        opt.textContent = t;
+        templateSelect.appendChild(opt);
+      });
+    });
+}
+
+function updateCover() {
+  const files = audioInput.files;
+  if (!files.length) return;
+  const fd = new FormData();
+  fd.append('audio', files[0]);
+  fd.append('title', titleInput.value);
+  fd.append('genre', genreInput.value);
+  fd.append('template', templateSelect.value);
+  fd.append('last_modified', files[0].lastModified);
+  fetch('/cover_art', { method: 'POST', body: fd })
+    .then(r => r.json())
+    .then(data => {
+      titleInput.value = data.title;
+      genreInput.value = data.genre;
+      coverArea.innerHTML = `<iframe src="${data.url}" width="500" height="500"></iframe>`;
+      coverDownload.href = data.url;
+    });
+}
+
+audioInput.addEventListener('change', updateCover);
+titleInput.addEventListener('input', updateCover);
+genreInput.addEventListener('input', updateCover);
+templateSelect.addEventListener('change', updateCover);
+
+document.addEventListener('DOMContentLoaded', loadTemplates);

--- a/templates/cover_templates/default.html
+++ b/templates/cover_templates/default.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+<style>
+  body { width: 500px; height: 500px; position: relative; background: #eee; }
+  #title { position: absolute; top: 200px; width: 100%; text-align: center; font-size: 24px; }
+  #date { position: absolute; top: 250px; width: 100%; text-align: center; font-size: 16px; }
+  #day { position: absolute; top: 270px; width: 100%; text-align: center; font-size: 16px; }
+  #genre { position: absolute; top: 290px; width: 100%; text-align: center; font-size: 16px; }
+</style>
+</head>
+<body>
+  <div id="title">{{ title }}</div>
+  <div id="date">{{ date }}</div>
+  <div id="day">{{ day }}</div>
+  <div id="genre">{{ genre }}</div>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,12 @@
   <form action="{{ url_for('mix') }}" method="post" enctype="multipart/form-data">
     <label for="audio">ポッドキャスト音声:</label>
     <input type="file" name="audio" id="audio" required><br><br>
+    <label for="title">タイトル:</label>
+    <input type="text" id="title"><br><br>
+    <label for="genre">ジャンル:</label>
+    <input type="text" id="genre"><br><br>
+    <label for="template">カバーアートテンプレート:</label>
+    <select id="template"></select><br><br>
     <label for="bgm">BGM:</label>
     <select name="bgm" id="bgm" required>
       {% for group_data in options %}
@@ -26,7 +32,11 @@
     <audio id="previewAudio"></audio>
     <button type="submit">ミックスしてダウンロード</button>
   </form>
+  <h2>カバーアート</h2>
+  <div id="coverArea"></div>
+  <a id="coverDownload" href="#">カバーアートダウンロード</a>
   <script src="{{ url_for('static', filename='js/preview.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/cover.js') }}"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- implement cover art generation endpoints
- add default cover art template
- add cover art preview script and fields

## Testing
- `python -m py_compile app.py work.py`

------
https://chatgpt.com/codex/tasks/task_e_685639d454c883229612ab04df0256e6