### PR TITLE
Issue #14: persist template and volume settings

### DIFF
--- a/static/js/savecontrol.js
+++ b/static/js/savecontrol.js
@@ -1,18 +1,39 @@
+// ページ読み込み時に値を復元し、変更があれば保存
 document.addEventListener('DOMContentLoaded', () => {
   const ctrls = document.querySelectorAll('.savecontrol');
   ctrls.forEach(ctrl => {
     const key = `save_${ctrl.id}`;
-    const stored = localStorage.getItem(key);
-    if (stored !== null) {
-      if (ctrl.type === 'checkbox') {
-        ctrl.checked = stored === 'true';
-      } else {
-        ctrl.value = stored;
+    let stored = localStorage.getItem(key);
+
+    // 保存済みの値をコントロールに反映
+    const restore = () => {
+      if (stored !== null) {
+        if (ctrl.type === 'checkbox') {
+          ctrl.checked = stored === 'true';
+        } else {
+          ctrl.value = stored;
+        }
       }
+    };
+
+    restore();
+
+    // select要素は後からoptionが追加されることがある
+    if (ctrl.tagName.toLowerCase() === 'select') {
+      const observer = new MutationObserver(() => {
+        restore();
+        if (ctrl.value === stored) {
+          observer.disconnect();
+        }
+      });
+      observer.observe(ctrl, { childList: true });
     }
+
+    // 値が変化したら保存
     const save = () => {
       const value = ctrl.type === 'checkbox' ? ctrl.checked : ctrl.value;
-      localStorage.setItem(key, value);
+      stored = value.toString();
+      localStorage.setItem(key, stored);
     };
     ctrl.addEventListener('change', save);
     ctrl.addEventListener('input', save);

--- a/static/js/savecontrol.js
+++ b/static/js/savecontrol.js
@@ -10,6 +10,11 @@ document.addEventListener('DOMContentLoaded', () => {
       if (stored !== null) {
         if (ctrl.type === 'checkbox') {
           ctrl.checked = stored === 'true';
+        } else if (ctrl.tagName.toLowerCase() === 'select') {
+          const exists = Array.from(ctrl.options).some(opt => opt.value === stored);
+          if (exists) {
+            ctrl.value = stored;
+          }
         } else {
           ctrl.value = stored;
         }

--- a/static/js/savecontrol.js
+++ b/static/js/savecontrol.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const ctrls = document.querySelectorAll('.savecontrol');
+  ctrls.forEach(ctrl => {
+    const key = `save_${ctrl.id}`;
+    const stored = localStorage.getItem(key);
+    if (stored !== null) {
+      if (ctrl.type === 'checkbox') {
+        ctrl.checked = stored === 'true';
+      } else {
+        ctrl.value = stored;
+      }
+    }
+    const save = () => {
+      const value = ctrl.type === 'checkbox' ? ctrl.checked : ctrl.value;
+      localStorage.setItem(key, value);
+    };
+    ctrl.addEventListener('change', save);
+    ctrl.addEventListener('input', save);
+  });
+});

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,7 +18,7 @@
     <label for="date">配信日:</label>
     <input type="date" id="date"><br><br>
     <label for="template">カバーアートテンプレート:</label>
-    <select id="template"></select><br><br>
+    <select id="template" class="savecontrol"></select><br><br>
     <label for="bgm">BGM:</label>
     <select name="bgm" id="bgm" required>
       {% for group_data in options %}
@@ -30,7 +30,7 @@
       {% endfor %}
     </select><br><br>
     <label for="target_db">目標音量(dB):</label>
-    <input type="number" name="target_db" id="target_db" value="{{ target_db }}" step="0.1"><br><br>
+    <input type="number" name="target_db" id="target_db" value="{{ target_db }}" step="0.1" class="savecontrol"><br><br>
     <button type="button" id="previewBtn">BGM視聴</button><br><br>
     <audio id="previewAudio"></audio>
     <button type="submit">ミックスしてダウンロード</button>
@@ -39,6 +39,7 @@
   <div id="coverArea"><iframe id="coverFrame"></iframe></div>
   <a id="coverDownload" href="#">カバーアートダウンロード</a>
   <script src="{{ url_for('static', filename='js/preview.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/savecontrol.js') }}"></script>
   <script src="{{ url_for('static', filename='js/html2canvas.min.js') }}"></script>
   <script src="{{ url_for('static', filename='js/cover.js') }}"></script>
 </body>


### PR DESCRIPTION
## Summary
- add generic `savecontrol` JS that stores values to localStorage
- mark template selector and volume input to use the new script

## Testing
- `python -m py_compile app.py work.py`


------
https://chatgpt.com/codex/tasks/task_e_6858468c05b88322ae284df033ff5db3