### PR TITLE
Use UUID for output filenames

### DIFF
--- a/static/js/cover.js
+++ b/static/js/cover.js
@@ -45,6 +45,7 @@
             coverFrame.srcdoc = html;
           });
         coverDownload.dataset.url = data.url;
+        coverDownload.dataset.filename = `cover_${data.uuid}.png`;
       });
   }
 
@@ -68,7 +69,7 @@
     html2canvas(body, { scale }).then(canvas => {
       const a = document.createElement('a');
       a.href = canvas.toDataURL('image/png');
-      a.download = 'cover.png';
+      a.download = coverDownload.dataset.filename || 'cover.png';
       a.click();
     });
   });

--- a/static/js/mix.js
+++ b/static/js/mix.js
@@ -23,6 +23,9 @@
     mixProgress.style.display = 'inline-block';
     try {
       const fd = new FormData(form);
+      if (audioInput.files.length) {
+        fd.append('last_modified', audioInput.files[0].lastModified);
+      }
       const res = await fetch(form.action, {
         method: 'POST',
         body: fd,
@@ -33,6 +36,11 @@
       mixedAudio.src = url;
       mixedAudio.playbackRate = parseFloat(mixedRate.value);
       mixedDownload.href = url;
+      const disp = res.headers.get('Content-Disposition');
+      const m = disp && disp.match(/filename="(.+)"/);
+      if (m) {
+        mixedDownload.download = m[1];
+      }
     } catch (e) {
       if (e.name !== 'AbortError') {
         console.error(e);

--- a/static/js/mix.js
+++ b/static/js/mix.js
@@ -37,9 +37,12 @@
       mixedAudio.playbackRate = parseFloat(mixedRate.value);
       mixedDownload.href = url;
       const disp = res.headers.get('Content-Disposition');
-      const m = disp && disp.match(/filename="(.+)"/);
-      if (m) {
-        mixedDownload.download = m[1];
+      if (disp) {
+        // ヘッダからファイル名を取得（引用符があってもなくても対応）
+        const m = disp.match(/filename\\*?=(?:UTF-8''|\"?)([^\";]+)/);
+        if (m) {
+          mixedDownload.download = m[1];
+        }
       }
     } catch (e) {
       if (e.name !== 'AbortError') {


### PR DESCRIPTION
## Summary
- manage a UUID that resets when the audio file changes
- send the UUID in `/cover_art` responses
- forward the file's last modified time in JS
- update download filenames using the UUID

## Testing
- `python -m py_compile app.py work.py`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685cfd831adc8322b985612e18912e4c