### PR TITLE
自動BGM選択機能の拡張

### DIFF
--- a/app.py
+++ b/app.py
@@ -85,7 +85,12 @@ def get_bgm_options():
 
       if group_label not in grouped_options:
         grouped_options[group_label] = []
-      grouped_options[group_label].append({'file': file_value, 'label': label, 'stem': fname_leaf})
+      grouped_options[group_label].append({
+        'file': file_value,
+        'label': label,
+        'stem': fname_leaf,
+        'basename': os.path.splitext(fname_leaf)[0]
+      })
 
   # テンプレートで使いやすいように整形し、ソートする
   options_for_template = []

--- a/static/js/mix.js
+++ b/static/js/mix.js
@@ -50,10 +50,25 @@
     return false;
   }
 
+  // ファイル名に含まれるBGM名から選択
+  function selectBgmByName(fileName) {
+    const select = document.getElementById('bgm');
+    const baseName = fileName.replace(/\.[^/.]+$/, '').toLowerCase();
+    for (const opt of select.options) {
+      const bn = (opt.dataset.basename || '').toLowerCase();
+      if (bn && baseName.includes(bn)) {
+        select.value = opt.value;
+        return true;
+      }
+    }
+    return false;
+  }
+
   // #audio に設定されたファイル名からBGMを自動選択
   function autoSelectBgm() {
     if (!audioInput.files.length) return;
     const name = audioInput.files[0].name;
+    if (selectBgmByName(name)) return;
     const m = name.match(/^(\d{4}-\d{2}-\d{2})/);
     if (!m) return;
     const date = new Date(m[1]);

--- a/templates/index.html
+++ b/templates/index.html
@@ -39,7 +39,7 @@
         {% for group_data in options %}
         <optgroup label="{{ group_data.group_label }}">
           {% for opt in group_data.options %}
-          <option value="{{ opt.file }}">{{ opt.label }}({{ opt.stem }})</option>
+          <option value="{{ opt.file }}" data-basename="{{ opt.basename }}">{{ opt.label }}({{ opt.stem }})</option>
           {% endfor %}
         </optgroup>
         {% endfor %}


### PR DESCRIPTION
## Summary
- テンプレートのoptionにBGMファイル名(拡張子除く)を保持
- BGM一覧作成処理にbasenameを追加
- 音声ファイル名にBGM名が含まれている場合は自動で選択

## Testing
- `python -m py_compile app.py work.py`

------
https://chatgpt.com/codex/tasks/task_e_6862808ba5b083228f5bfbf6e567b7c7