### PR TITLE
Reduce cover art update frequency

### DIFF
--- a/static/js/cover.js
+++ b/static/js/cover.js
@@ -56,8 +56,9 @@
     dateInput.value = '';
     updateCover();
   });
-  titleInput.addEventListener('input', updateCover);
-  genreInput.addEventListener('input', updateCover);
+  // テキストボックスからフォーカスが外れたときに更新
+  titleInput.addEventListener('blur', updateCover);
+  genreInput.addEventListener('blur', updateCover);
   templateSelect.addEventListener('change', updateCover);
   dateInput.addEventListener('change', updateCover);
 


### PR DESCRIPTION
## Summary
- update cover art generation only when text boxes lose focus

## Testing
- `python -m py_compile app.py work.py`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687cb692cea883229b759db6e64e8238