### PR TITLE
feat: 初期ノイズ除去機能の追加

### DIFF
--- a/app.py
+++ b/app.py
@@ -143,6 +143,7 @@ def mix():
   artist = request.form.get('artist') or ''
   release_date = request.form.get('date') or None
   target_str = request.form.get('target_db', str(DEFAULT_TARGET_DB))
+  noise_reduction = request.form.get('noise_reduction', 'none')
   try:
     target_db = float(target_str)
   except ValueError:
@@ -163,7 +164,8 @@ def mix():
 
   file.stream.seek(0)
   podcast = AudioSegment.from_file(file)
-  podcast = reduce_noise(podcast)
+  if noise_reduction and noise_reduction == "1stOne":
+    podcast = reduce_noise(podcast)
   podcast = normalize_volume(podcast, target_db)
 
   final_mix = set_bgm(podcast, bgm_name)

--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ from flask import Flask, render_template, request, redirect, url_for, send_file,
 from mutagen.easyid3 import EasyID3
 from mutagen import File as MutagenFile
 from pydub import AudioSegment
-from work import set_bgm, normalize_volume, DEFAULT_TARGET_DB
+from work import set_bgm, normalize_volume, DEFAULT_TARGET_DB, reduce_noise
 
 
 app = Flask(__name__)
@@ -163,6 +163,7 @@ def mix():
 
   file.stream.seek(0)
   podcast = AudioSegment.from_file(file)
+  podcast = reduce_noise(podcast)
   podcast = normalize_volume(podcast, target_db)
 
   final_mix = set_bgm(podcast, bgm_name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 Flask
 mutagen
 pydub
+numpy
+noisereduce

--- a/templates/index.html
+++ b/templates/index.html
@@ -51,6 +51,13 @@
         <label for="target_db">目標音量(dB):</label>
         <input type="number" name="target_db" id="target_db" value="{{ target_db }}" step="0.1" class="savecontrol">
       </div>
+      <div class="form-item">
+        <label>ノイズ除去:</label>
+        <select id="noise_reduction" name="noise_reduction" class="savecontrol">
+          <option value="none">なし</option>
+          <option value="1stOne">最初の一秒をノイズ扱いとして除去</option>
+        </select>
+      </div>
       <a id="archiveDownload" href="#">アーカイブ音声ダウンロード</a>
       <div class="form-item">
         <audio id="previewAudio"></audio>


### PR DESCRIPTION
## Summary
- 最初の1秒をノイズサンプルとして全体から除去するreduce_noise関数を追加
- ノイズ除去処理をミックス処理前に適用
- noisereduceとnumpyを依存関係に追加

## Testing
- `pip install -r requirements.txt -q`
- `python -m py_compile work.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68996689b8288322b412da0a938f5327