### PR TITLE
ノイズ除去オプションの追加

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ from flask import Flask, render_template, request, redirect, url_for, send_file,
 from mutagen.easyid3 import EasyID3
 from mutagen import File as MutagenFile
 from pydub import AudioSegment
-from work import set_bgm, normalize_volume, DEFAULT_TARGET_DB
+from work import set_bgm, normalize_volume, DEFAULT_TARGET_DB, reduce_noise
 
 
 app = Flask(__name__)
@@ -143,6 +143,7 @@ def mix():
   artist = request.form.get('artist') or ''
   release_date = request.form.get('date') or None
   target_str = request.form.get('target_db', str(DEFAULT_TARGET_DB))
+  noise_reduction = request.form.get('noise_reduction')
   try:
     target_db = float(target_str)
   except ValueError:
@@ -164,6 +165,9 @@ def mix():
   file.stream.seek(0)
   podcast = AudioSegment.from_file(file)
   podcast = normalize_volume(podcast, target_db)
+  if noise_reduction:
+    # ノイズ除去を適用
+    podcast = reduce_noise(podcast)
 
   final_mix = set_bgm(podcast, bgm_name)
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -51,6 +51,10 @@
         <label for="target_db">目標音量(dB):</label>
         <input type="number" name="target_db" id="target_db" value="{{ target_db }}" step="0.1" class="savecontrol">
       </div>
+      <div class="form-item">
+        <label for="noise_reduction">ノイズ除去:</label>
+        <input type="checkbox" id="noise_reduction" name="noise_reduction">
+      </div>
       <a id="archiveDownload" href="#">アーカイブ音声ダウンロード</a>
       <div class="form-item">
         <audio id="previewAudio"></audio>

--- a/work.py
+++ b/work.py
@@ -12,6 +12,11 @@ def normalize_volume(audio: AudioSegment, target_db: float = DEFAULT_TARGET_DB) 
   gain = target_dbfs - audio.dBFS
   return audio.apply_gain(gain)
 
+
+def reduce_noise(audio: AudioSegment) -> AudioSegment:
+  """簡易ノイズ除去: 低周波ノイズを抑制"""
+  return audio.high_pass_filter(200)
+
 BGM_FOLDER = os.path.join(os.path.dirname(__file__), 'bgm')
 BGM_DUCK_DB = -20.0 # BGMをポッドキャスト再生中に10%の音量にする（約-20dB） 20 * log10(0.1) = -20 dB
 


### PR DESCRIPTION
## 概要
- ミックスフォームにノイズ除去チェックボックスを追加
- ノイズ除去の指定時に `reduce_noise` を適用する処理を追加
- 簡易ノイズ除去処理を実装

## テスト
- `python -m py_compile app.py work.py`
- フォーム送信: チェックなし/ありで `/mix` を呼び出し、応答MP3のハッシュが変化することを確認


------
https://chatgpt.com/codex/tasks/task_e_68996f7661b0832288c342d55fd26f49