### PR TITLE
カスタムBGMの一時利用機能を追加

### DIFF
--- a/app.py
+++ b/app.py
@@ -136,6 +136,7 @@ def bgm(filename):
 @app.route('/mix', methods=['POST'])
 def mix():
   file = request.files.get('audio')
+  custom_bgm_file = request.files.get('custom_bgm')
   last_modified = request.form.get('last_modified')
   bgm_name = request.form.get('bgm')
   title = request.form.get('title') or ''
@@ -148,11 +149,13 @@ def mix():
     target_db = float(target_str)
   except ValueError:
     target_db = DEFAULT_TARGET_DB
-  if not file or not bgm_name:
+  use_custom_bgm = bool(custom_bgm_file and custom_bgm_file.filename)
+
+  if not file or (not bgm_name and not use_custom_bgm):
     return redirect(url_for('index'))
 
   release_date = extract_release_date(file, last_modified, release_date)
-  album = get_album_name(bgm_name)
+  album = '' if use_custom_bgm else get_album_name(bgm_name)
 
   # 入力音声のID3タグを取得
   try:
@@ -173,7 +176,12 @@ def mix():
       pass
   podcast = normalize_volume(podcast, target_db)
 
-  final_mix = set_bgm(podcast, bgm_name)
+  if use_custom_bgm:
+    custom_bgm_file.stream.seek(0)
+    custom_bgm = AudioSegment.from_file(custom_bgm_file)
+    final_mix = set_bgm(podcast, custom_bgm)
+  else:
+    final_mix = set_bgm(podcast, bgm_name)
 
   uuid_val = update_uuid(file, last_modified)
   output_name = f"{uuid_val}.mp3"

--- a/static/js/mix.js
+++ b/static/js/mix.js
@@ -2,6 +2,7 @@
   // ミックス処理を自動化
   const form = document.querySelector('form');
   const audioInput = document.getElementById('audio');
+  const customBgmInput = document.getElementById('customBgm');
   const mixedAudio = document.getElementById('mixedAudio');
   const mixedDownload = document.getElementById('mixedDownload');
   const mixProgress = document.getElementById('mixProgress');
@@ -73,6 +74,7 @@
   // #audio に設定されたファイル名からBGMを自動選択
   function autoSelectBgm() {
     if (!audioInput.files.length) return;
+    if (customBgmInput.files.length) return;
     const name = audioInput.files[0].name;
     if (selectBgmByName(name)) return;
     const m = name.match(/^(\d{4}-\d{2}-\d{2})/);
@@ -133,4 +135,3 @@
     mix();
   });
 })();
-

--- a/static/js/preview.js
+++ b/static/js/preview.js
@@ -1,11 +1,24 @@
 (() => {
   const previewBtn = document.getElementById('previewBtn');
   const bgmSelect = document.getElementById('bgm');
+  const customBgmInput = document.getElementById('customBgm');
   const previewAudio = document.getElementById('previewAudio');
+  let customPreviewUrl = null;
+
+  function updateBgmControlState() {
+    const hasCustomBgm = customBgmInput.files.length > 0;
+    bgmSelect.disabled = hasCustomBgm;
+    bgmSelect.required = !hasCustomBgm;
+    if (!previewAudio.paused) {
+      previewAudio.pause();
+      previewAudio.currentTime = 0;
+    }
+    previewBtn.textContent = 'BGM視聴';
+  }
 
   previewBtn.addEventListener('click', () => {
-    const selected = bgmSelect.value;
-    if (!selected) {
+    const hasCustomBgm = customBgmInput.files.length > 0;
+    if (!hasCustomBgm && !bgmSelect.value) {
       return;
     }
     if (!previewAudio.paused) {
@@ -15,7 +28,15 @@
       previewBtn.textContent = 'BGM視聴';
       return;
     }
-    previewAudio.src = `/bgm/${selected}`;
+    if (hasCustomBgm) {
+      if (customPreviewUrl) {
+        URL.revokeObjectURL(customPreviewUrl);
+      }
+      customPreviewUrl = URL.createObjectURL(customBgmInput.files[0]);
+      previewAudio.src = customPreviewUrl;
+    } else {
+      previewAudio.src = `/bgm/${bgmSelect.value}`;
+    }
     previewAudio.play();
     previewBtn.textContent = '停止';
   });
@@ -29,4 +50,7 @@
   previewAudio.addEventListener('ended', () => {
     previewBtn.textContent = 'BGM視聴';
   });
+
+  customBgmInput.addEventListener('change', updateBgmControlState);
+  updateBgmControlState();
 })();

--- a/templates/index.html
+++ b/templates/index.html
@@ -50,7 +50,6 @@
       <div class="form-item">
         <label for="customBgm">カスタムBGM:</label>
         <input type="file" id="customBgm" name="custom_bgm" accept="audio/*">
-        <small>設定中は既存BGM選択が無効になります（保存されません）</small>
       </div>
       <div class="form-item">
         <label for="target_db">目標音量(dB):</label>

--- a/templates/index.html
+++ b/templates/index.html
@@ -48,6 +48,11 @@
         <button type="button" id="previewBtn" class="preview-btn">BGM視聴</button>
       </div>
       <div class="form-item">
+        <label for="customBgm">カスタムBGM:</label>
+        <input type="file" id="customBgm" name="custom_bgm" accept="audio/*">
+        <small>設定中は既存BGM選択が無効になります（保存されません）</small>
+      </div>
+      <div class="form-item">
         <label for="target_db">目標音量(dB):</label>
         <input type="number" name="target_db" id="target_db" value="{{ target_db }}" step="0.1" class="savecontrol">
       </div>

--- a/work.py
+++ b/work.py
@@ -45,38 +45,41 @@ BGM_FOLDER = os.path.join(os.path.dirname(__file__), 'bgm')
 BGM_DUCK_DB = -20.0 # BGMをポッドキャスト再生中に10%の音量にする（約-20dB） 20 * log10(0.1) = -20 dB
 
 
-def set_bgm(source: AudioSegment, bgm_name: str,
+def set_bgm(source: AudioSegment, bgm_source,
             intro_duration_ms: int = 5000,
             outro_duration_ms: int = 5000) -> AudioSegment:
-    """Combine intro/outro BGM with source audio and duck BGM during the body."""
-    bgm_path = os.path.join(BGM_FOLDER, bgm_name)
+  """イントロ・本編・アウトロにBGMを合成する。"""
+  if isinstance(bgm_source, AudioSegment):
+    bgm_audio = bgm_source
+  else:
+    bgm_path = os.path.join(BGM_FOLDER, bgm_source)
     bgm_audio = AudioSegment.from_file(bgm_path)
 
-    podcast_duration_ms = len(source)
-    total_duration_ms = intro_duration_ms + podcast_duration_ms + outro_duration_ms
+  podcast_duration_ms = len(source)
+  total_duration_ms = intro_duration_ms + podcast_duration_ms + outro_duration_ms
 
-    full_bgm = bgm_audio
-    if len(full_bgm) < total_duration_ms:
-        num_loops = (total_duration_ms + len(full_bgm) - 1) // len(full_bgm)
-        full_bgm *= num_loops
-    full_bgm = full_bgm[:total_duration_ms]
+  full_bgm = bgm_audio
+  if len(full_bgm) < total_duration_ms:
+    num_loops = (total_duration_ms + len(full_bgm) - 1) // len(full_bgm)
+    full_bgm *= num_loops
+  full_bgm = full_bgm[:total_duration_ms]
 
-    intro_bgm = full_bgm[:intro_duration_ms]
+  intro_bgm = full_bgm[:intro_duration_ms]
 
-    body_bgm_start = intro_duration_ms
-    body_bgm_end = intro_duration_ms + podcast_duration_ms
-    body_bgm = full_bgm[body_bgm_start:body_bgm_end]
+  body_bgm_start = intro_duration_ms
+  body_bgm_end = intro_duration_ms + podcast_duration_ms
+  body_bgm = full_bgm[body_bgm_start:body_bgm_end]
 
-    outro_bgm_start = body_bgm_end
-    outro_bgm = full_bgm[outro_bgm_start:total_duration_ms]
+  outro_bgm_start = body_bgm_end
+  outro_bgm = full_bgm[outro_bgm_start:total_duration_ms]
 
-    fade_out_duration_ms = 1000
-    if len(outro_bgm) >= fade_out_duration_ms:
-        outro_bgm = outro_bgm.fade_out(fade_out_duration_ms)
-    elif len(outro_bgm) > 0:
-        outro_bgm = outro_bgm.fade_out(len(outro_bgm))
+  fade_out_duration_ms = 1000
+  if len(outro_bgm) >= fade_out_duration_ms:
+    outro_bgm = outro_bgm.fade_out(fade_out_duration_ms)
+  elif len(outro_bgm) > 0:
+    outro_bgm = outro_bgm.fade_out(len(outro_bgm))
 
-    body = body_bgm.overlay(source, gain_during_overlay=BGM_DUCK_DB)
+  body = body_bgm.overlay(source, gain_during_overlay=BGM_DUCK_DB)
 
-    final_mix = intro_bgm + body + outro_bgm
-    return final_mix
+  final_mix = intro_bgm + body + outro_bgm
+  return final_mix


### PR DESCRIPTION
### Motivation
- ユーザーがリクエスト単位でローカルの音声ファイルをBGMとしてアップロードして利用できるようにするため。 

### Description
- フロントエンドにカスタムBGM用のファイル入力欄を追加して `templates/index.html` から `custom_bgm` を送信できるようにしました。 
- プレビュー動作を `static/js/preview.js` で更新し、カスタムBGM選択中は既存BGMセレクトを無効化してローカルプレビューを再生するようにしました。 
- 自動BGM選択処理を `static/js/mix.js` で調整し、カスタムBGMが設定されている場合は既存BGMの自動選択を行わないようにしました。 
- サーバー側を `app.py` 側で `custom_bgm` を受け取り、指定がある場合は永続化せずに `AudioSegment` として `set_bgm` に渡すようにし、`work.py` の `set_bgm` をファイル名または `AudioSegment` を受け取れるように拡張しました。 

### Testing
- `python -m py_compile app.py work.py` を実行して構文チェックを行い成功しました。 
- `node --check static/js/mix.js && node --check static/js/preview.js` を実行してフロントエンドスクリプトの構文チェックを行い成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d104dff4e083229edb56f4cba9d399)